### PR TITLE
NCSD-1942: Changed subscription name

### DIFF
--- a/Resources/ArmTemplates/template.json
+++ b/Resources/ArmTemplates/template.json
@@ -82,7 +82,7 @@
         "functionAppInsightsName": "[concat(variables('functionAppName'), '-ai')]",
         "urlJobProfileCurrentOpportunities": "[toLower(concat('https://', variables('webAppName'), '.', parameters('appServiceDomain')))]",
         "cmsTopicName": "cms-messages",
-        "cmsSubscriptionName": "job-profile-metadata",
+        "cmsSubscriptionName": "job-profile-currentopportunities",
         "refreshTopicName": "job-profile-refresh"
     },
     "resources": [


### PR DESCRIPTION
Subscription name was incorrect: was job-profile-metadata changed to job-profile-currentopportunities