### PR TITLE
Configure default level logging for AppInsights

### DIFF
--- a/Resources/ArmTemplates/template.json
+++ b/Resources/ArmTemplates/template.json
@@ -344,6 +344,10 @@
                             {
                                 "name": "Configuration__CourseSearchClient__CourseSearchSvc__RequestTimeOutSeconds",
                                 "value": "10"
+                            },
+                            {
+                                "name": "Logging__ApplicationInsights__LogLevel__Default",
+                                "value": "Information"
                             }
                         ]
                     }

--- a/Resources/ArmTemplates/template.json
+++ b/Resources/ArmTemplates/template.json
@@ -480,6 +480,10 @@
                             {
                                 "name": "Policies__HttpRetry__Count",
                                 "value": "3"
+                            },
+                            {
+                                "name": "Logging__ApplicationInsights__LogLevel__Default",
+                                "value": "Information"
                             }                            
                         ]
                     }


### PR DESCRIPTION
Added default level as "Information" for application insights