### PR TITLE
Story/dfc 10810 client throws message size exceeded exception

### DIFF
--- a/DFC.App.JobProfile.CurrentOpportunities.IntegrationTests/ControllerTests/SegmentControllerRouteTests.cs
+++ b/DFC.App.JobProfile.CurrentOpportunities.IntegrationTests/ControllerTests/SegmentControllerRouteTests.cs
@@ -117,6 +117,7 @@ namespace DFC.App.JobProfile.CurrentOpportunities.IntegrationTests.ControllerTes
             _ = await client.PostAsync(url, currentOpportunitiesSegmentModel, new JsonMediaTypeFormatter()).ConfigureAwait(false);
 
             currentOpportunitiesSegmentModel.SequenceNumber++;
+
             // Act
             var response = await client.PutAsync(url, currentOpportunitiesSegmentModel, new JsonMediaTypeFormatter()).ConfigureAwait(false);
 

--- a/DFC.App.JobProfile.CurrentOpportunities.IntegrationTests/DataSeeding.cs
+++ b/DFC.App.JobProfile.CurrentOpportunities.IntegrationTests/DataSeeding.cs
@@ -47,7 +47,7 @@ namespace DFC.App.JobProfile.CurrentOpportunities.IntegrationTests
             {
                 LastReviewed = DateTime.UtcNow,
                 JobTitle = $"JobProfile{index}",
-                Apprenticeships = new Apprenticeships()//Standards and frameworks should be valid or integration tests will fail
+                Apprenticeships = new Apprenticeships() //Standards and frameworks should be valid or integration tests will fail
                 {
                     Standards = new List<ApprenticeshipStandard>()
                     {

--- a/DFC.App.JobProfile.CurrentOpportunities.IntegrationTests/appsettings-template.json
+++ b/DFC.App.JobProfile.CurrentOpportunities.IntegrationTests/appsettings-template.json
@@ -48,7 +48,9 @@
         "APIKey": "--enter course search API key here--",
         "SearchPageSize": 20,
         "AttendanceModes": "AM1,AM2,AM3,AM4,AM5,AM6,AM7,AM8,AM9",
-        "RequestTimeOutSeconds": 10
+        "RequestTimeOutSeconds": 10,
+        "MaxReceivedMessageSize": 2147483647,
+        "MaxBufferSize": 2147483647
       }
     }
   },

--- a/DFC.App.JobProfile.CurrentOpportunities.MFA.UnitTests/Services/RefreshServicetests/RefreshServiceRefreshApprenticeshipsTests.cs
+++ b/DFC.App.JobProfile.CurrentOpportunities.MFA.UnitTests/Services/RefreshServicetests/RefreshServiceRefreshApprenticeshipsTests.cs
@@ -50,7 +50,7 @@ namespace DFC.App.JobProfile.CurrentOpportunities.MFA.UnitTests.Services.Refresh
             // arrange
             var documentId = Guid.NewGuid();
             var expectedStatusCode = HttpStatusCode.BadRequest;
-            var expectedResults = A.Fake<FeedRefreshResponsModel>();
+            var expectedResults = A.Fake<FeedRefreshResponseModel>();
             using var messageHandler = FakeHttpMessageHandler.GetHttpMessageHandler(JsonConvert.SerializeObject(expectedResults), expectedStatusCode);
             using var httpClient = new HttpClient(messageHandler);
             var refreshService = new RefreshService(httpClient, fakeLogger, fakeRefreshClientOptions);

--- a/DFC.App.JobProfile.CurrentOpportunities.MFA.UnitTests/Services/RefreshServicetests/RefreshServiceRefreshCoursesTests.cs
+++ b/DFC.App.JobProfile.CurrentOpportunities.MFA.UnitTests/Services/RefreshServicetests/RefreshServiceRefreshCoursesTests.cs
@@ -50,7 +50,7 @@ namespace DFC.App.JobProfile.CurrentOpportunities.MFA.UnitTests.Services.Refresh
             // arrange
             var documentId = Guid.NewGuid();
             var expectedStatusCode = HttpStatusCode.BadRequest;
-            var expectedResults = A.Fake<FeedRefreshResponsModel>();
+            var expectedResults = A.Fake<FeedRefreshResponseModel>();
             using var messageHandler = FakeHttpMessageHandler.GetHttpMessageHandler(JsonConvert.SerializeObject(expectedResults), expectedStatusCode);
             using var httpClient = new HttpClient(messageHandler);
             var refreshService = new RefreshService(httpClient, fakeLogger, fakeRefreshClientOptions);

--- a/DFC.App.JobProfile.CurrentOpportunities.MessageFunctionApp/HttpClientPolicies/RefreshClientOptions.cs
+++ b/DFC.App.JobProfile.CurrentOpportunities.MessageFunctionApp/HttpClientPolicies/RefreshClientOptions.cs
@@ -1,5 +1,6 @@
 ﻿namespace DFC.App.JobProfile.CurrentOpportunities.MessageFunctionApp.HttpClientPolicies
 {
     public class RefreshClientOptions : SegmentClientOptions
-    { }
+    {
+    }
 }

--- a/DFC.App.JobProfile.CurrentOpportunities.MessageFunctionApp/Models/FeedRefreshResponseModel.cs
+++ b/DFC.App.JobProfile.CurrentOpportunities.MessageFunctionApp/Models/FeedRefreshResponseModel.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace DFC.App.JobProfile.CurrentOpportunities.MessageFunctionApp.Models
 {
-    public class FeedRefreshResponsModel
+    public class FeedRefreshResponseModel
     {
         public int NumberPulled { get; set; }
 

--- a/DFC.App.JobProfile.CurrentOpportunities.MessageFunctionApp/Services/RefreshService.cs
+++ b/DFC.App.JobProfile.CurrentOpportunities.MessageFunctionApp/Services/RefreshService.cs
@@ -78,7 +78,7 @@ namespace DFC.App.JobProfile.CurrentOpportunities.MessageFunctionApp.Services
                 else
                 {
                     var responseString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    var result = JsonConvert.DeserializeObject<FeedRefreshResponsModel>(responseString);
+                    var result = JsonConvert.DeserializeObject<FeedRefreshResponseModel>(responseString);
 
                     logger.LogError($"{nameof(RefreshApprenticeshipsAsync)}: Error refreshing Job Profile Apprenticeships from {url}, status: {response.StatusCode}, response message: {result.RequestErrorMessage}");
                 }
@@ -114,7 +114,7 @@ namespace DFC.App.JobProfile.CurrentOpportunities.MessageFunctionApp.Services
                 else
                 {
                     var responseString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    var result = JsonConvert.DeserializeObject<FeedRefreshResponsModel>(responseString);
+                    var result = JsonConvert.DeserializeObject<FeedRefreshResponseModel>(responseString);
 
                     logger.LogError($"{nameof(RefreshCoursesAsync)}: Error refreshing Job Profile Courses from {url}, status: {response.StatusCode}, response message: {result.RequestErrorMessage}");
                 }

--- a/DFC.App.JobProfile.CurrentOpportunities/DFC.App.JobProfile.CurrentOpportunities.csproj
+++ b/DFC.App.JobProfile.CurrentOpportunities/DFC.App.JobProfile.CurrentOpportunities.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="DFC.FindACourseClient" Version="1.1.0" />
+    <PackageReference Include="DFC.FindACourseClient" Version="1.2.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.7.1" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" />

--- a/DFC.App.JobProfile.CurrentOpportunities/appsettings-template.json
+++ b/DFC.App.JobProfile.CurrentOpportunities/appsettings-template.json
@@ -48,7 +48,9 @@
         "APIKey": "--enter course search API key here--",
         "SearchPageSize": 20,
         "AttendanceModes": "AM1,AM2,AM3,AM4,AM5,AM6,AM7,AM8,AM9",
-        "RequestTimeOutSeconds": 10
+        "RequestTimeOutSeconds": 10,
+        "MaxReceivedMessageSize": 2147483647,
+        "MaxBufferSize": 2147483647
       }
     }
   },

--- a/Resources/ArmTemplates/template.json
+++ b/Resources/ArmTemplates/template.json
@@ -344,6 +344,14 @@
                             {
                                 "name": "Configuration__CourseSearchClient__CourseSearchSvc__RequestTimeOutSeconds",
                                 "value": "10"
+                            },
+                            {
+                              "name": "Configuration__CourseSearchClient__CourseSearchSvc__MaxReceivedMessageSize",
+                              "value": "2147483647"
+                            },
+                            {
+                              "name": "Configuration__CourseSearchClient__CourseSearchSvc__MaxBufferSize",
+                              "value": "2147483647"
                             }
                         ]
                     }


### PR DESCRIPTION
Updated client packages as that has had a bug fixed for setting the message size.
Reduced warning