### PR TITLE
Bug/DFC-12986 add resilience to refreshes to stop intermittent behaviour

### DIFF
--- a/DFC.App.JobProfile.CurrentOpportunities.CourseService.UnitTests/CourseServiceTests/CourseCurrentOpportunitiesRefreshTests.cs
+++ b/DFC.App.JobProfile.CurrentOpportunities.CourseService.UnitTests/CourseServiceTests/CourseCurrentOpportunitiesRefreshTests.cs
@@ -60,7 +60,7 @@ namespace DFC.App.JobProfile.CurrentOpportunities.CourseService.UnitTests
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(2)]
-        public void RefreshCoursesAsync(int numberVacanciesFound)
+        public async Task RefreshCoursesAsync(int numberVacanciesFound)
         {
             //arrange
             A.CallTo(() => fakeRepository.GetAsync(A<Expression<Func<CurrentOpportunitiesSegmentModel, bool>>>.Ignored)).Returns(currentOpportunitiesSegmentModel);
@@ -70,7 +70,7 @@ namespace DFC.App.JobProfile.CurrentOpportunities.CourseService.UnitTests
             var courseCurrentOpportunitiesRefresh = new CourseCurrentOpportunitiesRefresh(fakeLogger, fakeRepository, fakeCourseSearchClient, fakeMapper, courseSearchSettings);
 
             //Act
-            var result = courseCurrentOpportunitiesRefresh.RefreshCoursesAsync(A.Dummy<Guid>()).Result;
+            var result = await courseCurrentOpportunitiesRefresh.RefreshCoursesAsync(A.Dummy<Guid>()).ConfigureAwait(false);
 
             //Asserts
             result.Should().Be(numberVacanciesFound);

--- a/DFC.App.JobProfile.CurrentOpportunities.MessageFunctionApp/DFC.App.JobProfile.CurrentOpportunities.MessageFunctionApp.csproj
+++ b/DFC.App.JobProfile.CurrentOpportunities.MessageFunctionApp/DFC.App.JobProfile.CurrentOpportunities.MessageFunctionApp.csproj
@@ -38,6 +38,9 @@
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </None>
+    <None Update="local.settings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="HttpClientPolicies\" />

--- a/DFC.App.JobProfile.CurrentOpportunities.SegmentService.UnitTests/SegmentServiceTests/SegmentServiceDeleteTests.cs
+++ b/DFC.App.JobProfile.CurrentOpportunities.SegmentService.UnitTests/SegmentServiceTests/SegmentServiceDeleteTests.cs
@@ -2,6 +2,7 @@
 using FakeItEasy;
 using System;
 using System.Net;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace DFC.App.JobProfile.CurrentOpportunities.SegmentService.UnitTests.SegmentServiceTests
@@ -14,7 +15,7 @@ namespace DFC.App.JobProfile.CurrentOpportunities.SegmentService.UnitTests.Segme
         }
 
         [Fact]
-        public void CareerPathSegmentServiceDeleteReturnsSuccessWhenSegmentDeleted()
+        public async Task CareerPathSegmentServiceDeleteReturnsSuccessWhenSegmentDeleted()
         {
             // arrange
             Guid documentId = Guid.NewGuid();
@@ -23,7 +24,7 @@ namespace DFC.App.JobProfile.CurrentOpportunities.SegmentService.UnitTests.Segme
             A.CallTo(() => FakeRepository.DeleteAsync(documentId)).Returns(HttpStatusCode.NoContent);
 
             // act
-            var result = CurrentOpportunitiesSegmentService.DeleteAsync(documentId).Result;
+            var result = await CurrentOpportunitiesSegmentService.DeleteAsync(documentId).ConfigureAwait(false);
 
             // assert
             A.CallTo(() => FakeRepository.DeleteAsync(documentId)).MustHaveHappenedOnceExactly();
@@ -31,7 +32,7 @@ namespace DFC.App.JobProfile.CurrentOpportunities.SegmentService.UnitTests.Segme
         }
 
         [Fact]
-        public void CareerPathSegmentServiceDeleteReturnsNullWhenSegmentNotDeleted()
+        public async Task CareerPathSegmentServiceDeleteReturnsNullWhenSegmentNotDeleted()
         {
             // arrange
             Guid documentId = Guid.NewGuid();
@@ -40,7 +41,7 @@ namespace DFC.App.JobProfile.CurrentOpportunities.SegmentService.UnitTests.Segme
             A.CallTo(() => FakeRepository.DeleteAsync(documentId)).Returns(HttpStatusCode.BadRequest);
 
             // act
-            var result = CurrentOpportunitiesSegmentService.DeleteAsync(documentId).Result;
+            var result = await CurrentOpportunitiesSegmentService.DeleteAsync(documentId).ConfigureAwait(false);
 
             // assert
             A.CallTo(() => FakeRepository.DeleteAsync(documentId)).MustHaveHappenedOnceExactly();
@@ -48,7 +49,7 @@ namespace DFC.App.JobProfile.CurrentOpportunities.SegmentService.UnitTests.Segme
         }
 
         [Fact]
-        public void CareerPathSegmentServiceDeleteReturnsFalseWhenMissingRepository()
+        public async Task CareerPathSegmentServiceDeleteReturnsFalseWhenMissingRepository()
         {
             // arrange
             Guid documentId = Guid.NewGuid();
@@ -58,7 +59,7 @@ namespace DFC.App.JobProfile.CurrentOpportunities.SegmentService.UnitTests.Segme
             A.CallTo(() => FakeRepository.DeleteAsync(documentId)).Returns(HttpStatusCode.FailedDependency);
 
             // act
-            var result = CurrentOpportunitiesSegmentService.DeleteAsync(documentId).Result;
+            var result = await CurrentOpportunitiesSegmentService.DeleteAsync(documentId).ConfigureAwait(false);
 
             // assert
             A.CallTo(() => FakeRepository.DeleteAsync(documentId)).MustHaveHappenedOnceExactly();

--- a/DFC.App.JobProfile.CurrentOpportunities.SegmentService.UnitTests/SegmentServiceTests/SegmentServicePingTests.cs
+++ b/DFC.App.JobProfile.CurrentOpportunities.SegmentService.UnitTests/SegmentServiceTests/SegmentServicePingTests.cs
@@ -1,4 +1,5 @@
 ﻿using FakeItEasy;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace DFC.App.JobProfile.CurrentOpportunities.SegmentService.UnitTests.SegmentServiceTests
@@ -11,14 +12,14 @@ namespace DFC.App.JobProfile.CurrentOpportunities.SegmentService.UnitTests.Segme
         }
 
         [Fact]
-        public void CareerPathSegmentServicePingReturnsSuccess()
+        public async Task CareerPathSegmentServicePingReturnsSuccess()
         {
             // arrange
             var expectedResult = true;
             A.CallTo(() => FakeRepository.PingAsync()).Returns(expectedResult);
 
             // act
-            var result = CurrentOpportunitiesSegmentService.PingAsync().Result;
+            var result = await CurrentOpportunitiesSegmentService.PingAsync().ConfigureAwait(false);
 
             // assert
             A.CallTo(() => FakeRepository.PingAsync()).MustHaveHappenedOnceExactly();
@@ -26,7 +27,7 @@ namespace DFC.App.JobProfile.CurrentOpportunities.SegmentService.UnitTests.Segme
         }
 
         [Fact]
-        public void CareerPathSegmentServicePingReturnsFalseWhenMissingRepository()
+        public async Task CareerPathSegmentServicePingReturnsFalseWhenMissingRepository()
         {
             // arrange
             var expectedResult = false;
@@ -34,7 +35,7 @@ namespace DFC.App.JobProfile.CurrentOpportunities.SegmentService.UnitTests.Segme
             A.CallTo(() => FakeRepository.PingAsync()).Returns(expectedResult);
 
             // act
-            var result = CurrentOpportunitiesSegmentService.PingAsync().Result;
+            var result = await CurrentOpportunitiesSegmentService.PingAsync().ConfigureAwait(false);
 
             // assert
             A.CallTo(() => FakeRepository.PingAsync()).MustHaveHappenedOnceExactly();

--- a/DFC.App.JobProfile.CurrentOpportunities.SegmentService.UnitTests/SegmentServiceTests/SegmentServiceUpsertTests.cs
+++ b/DFC.App.JobProfile.CurrentOpportunities.SegmentService.UnitTests/SegmentServiceTests/SegmentServiceUpsertTests.cs
@@ -18,7 +18,7 @@ namespace DFC.App.JobProfile.CurrentOpportunities.SegmentService.UnitTests.Segme
         }
 
         [Fact]
-        public void CurrentOpportunitiesSegementServiceCreateReturnsCreatedWhenSegmentCreated()
+        public async Task CurrentOpportunitiesSegementServiceCreateReturnsCreatedWhenSegmentCreated()
         {
             // arrange
             var currentOpportunitiesSegmentModel = A.Fake<CurrentOpportunitiesSegmentModel>();
@@ -27,7 +27,7 @@ namespace DFC.App.JobProfile.CurrentOpportunities.SegmentService.UnitTests.Segme
             A.CallTo(() => FakeRepository.UpsertAsync(A<CurrentOpportunitiesSegmentModel>.Ignored)).Returns(HttpStatusCode.Created);
 
             // act
-            var result = CurrentOpportunitiesSegmentService.UpsertAsync(currentOpportunitiesSegmentModel).Result;
+            var result = await CurrentOpportunitiesSegmentService.UpsertAsync(currentOpportunitiesSegmentModel).ConfigureAwait(false);
 
             // assert
             A.CallTo(() => FakeRepository.UpsertAsync(A<CurrentOpportunitiesSegmentModel>.Ignored)).MustHaveHappenedOnceExactly();
@@ -47,7 +47,7 @@ namespace DFC.App.JobProfile.CurrentOpportunities.SegmentService.UnitTests.Segme
         }
 
         [Fact]
-        public void CurrentOpportunitiesSegmentServiceCreateReturnsNullWhenSegmentNotCreated()
+        public async Task CurrentOpportunitiesSegmentServiceCreateReturnsNullWhenSegmentNotCreated()
         {
             // arrange
             var createOrUdateCareerPathSegmentModel = A.Fake<CurrentOpportunitiesSegmentModel>();
@@ -56,7 +56,7 @@ namespace DFC.App.JobProfile.CurrentOpportunities.SegmentService.UnitTests.Segme
             A.CallTo(() => FakeRepository.UpsertAsync(A<CurrentOpportunitiesSegmentModel>.Ignored)).Returns(HttpStatusCode.BadRequest);
 
             // act
-            var result = CurrentOpportunitiesSegmentService.UpsertAsync(createOrUdateCareerPathSegmentModel).Result;
+            var result = await CurrentOpportunitiesSegmentService.UpsertAsync(createOrUdateCareerPathSegmentModel).ConfigureAwait(false);
 
             // assert
             A.CallTo(() => FakeRepository.UpsertAsync(A<CurrentOpportunitiesSegmentModel>.Ignored)).MustHaveHappenedOnceExactly();
@@ -65,7 +65,7 @@ namespace DFC.App.JobProfile.CurrentOpportunities.SegmentService.UnitTests.Segme
         }
 
         [Fact]
-        public void CurrentOpportunitiesSegmentServiceCreateReturnsNullWhenMissingRepository()
+        public async Task CurrentOpportunitiesSegmentServiceCreateReturnsNullWhenMissingRepository()
         {
             // arrange
             var currentOpportunitiesSegmentModel = A.Fake<CurrentOpportunitiesSegmentModel>();
@@ -74,7 +74,7 @@ namespace DFC.App.JobProfile.CurrentOpportunities.SegmentService.UnitTests.Segme
             A.CallTo(() => FakeRepository.UpsertAsync(A<CurrentOpportunitiesSegmentModel>.Ignored)).Returns(HttpStatusCode.FailedDependency);
 
             // act
-            var result = CurrentOpportunitiesSegmentService.UpsertAsync(currentOpportunitiesSegmentModel).Result;
+            var result = await CurrentOpportunitiesSegmentService.UpsertAsync(currentOpportunitiesSegmentModel).ConfigureAwait(false);
 
             // assert
             A.CallTo(() => FakeRepository.UpsertAsync(A<CurrentOpportunitiesSegmentModel>.Ignored)).MustHaveHappenedOnceExactly();
@@ -86,14 +86,14 @@ namespace DFC.App.JobProfile.CurrentOpportunities.SegmentService.UnitTests.Segme
         [InlineData(HttpStatusCode.Created, true)]
         [InlineData(HttpStatusCode.OK, true)]
         [InlineData(HttpStatusCode.FailedDependency, false)]
-        public void CurrentOpportunitiesSegmentServiceUpdateCoursesAndAppreticeshipsWhenUpserted(HttpStatusCode upsertReturnCode, bool shouldRefresh)
+        public async Task CurrentOpportunitiesSegmentServiceUpdateCoursesAndAppreticeshipsWhenUpserted(HttpStatusCode upsertReturnCode, bool shouldRefresh)
         {
             // arrange
             var currentOpportunitiesSegmentModel = A.Fake<CurrentOpportunitiesSegmentModel>();
             A.CallTo(() => FakeRepository.UpsertAsync(A<CurrentOpportunitiesSegmentModel>.Ignored)).Returns(upsertReturnCode);
 
             // act
-            var result = CurrentOpportunitiesSegmentService.UpsertAsync(currentOpportunitiesSegmentModel).Result;
+            var result = await CurrentOpportunitiesSegmentService.UpsertAsync(currentOpportunitiesSegmentModel).ConfigureAwait(false);
 
             // assert
             A.CallTo(() => FakeRepository.UpsertAsync(A<CurrentOpportunitiesSegmentModel>.Ignored)).MustHaveHappenedOnceExactly();
@@ -111,7 +111,7 @@ namespace DFC.App.JobProfile.CurrentOpportunities.SegmentService.UnitTests.Segme
         }
 
         [Fact]
-        public void RefreshJobProfileMessageSentWhenOnlyCourseServiceFails()
+        public async Task RefreshJobProfileMessageSentWhenOnlyCourseServiceFails()
         {
             // arrange
             var currentOpportunitiesSegmentModel = A.Fake<CurrentOpportunitiesSegmentModel>();
@@ -120,14 +120,14 @@ namespace DFC.App.JobProfile.CurrentOpportunities.SegmentService.UnitTests.Segme
             A.CallTo(() => FakeCourseCurrentOpportunitiesRefresh.RefreshCoursesAsync(currentOpportunitiesSegmentModel.DocumentId)).Throws(new HttpRequestException());
 
             // act
-            var result = CurrentOpportunitiesSegmentService.UpsertAsync(currentOpportunitiesSegmentModel).Result;
+            var result = await CurrentOpportunitiesSegmentService.UpsertAsync(currentOpportunitiesSegmentModel).ConfigureAwait(false);
 
             // asserts
             A.CallTo(() => FakeJobProfileSegmentRefreshService.SendMessageAsync(A<RefreshJobProfileSegmentServiceBusModel>.Ignored)).MustHaveHappened();
         }
 
         [Fact]
-        public void RefreshJobProfileMessageSentWhenOnlyAVServiceFails()
+        public async Task RefreshJobProfileMessageSentWhenOnlyAVServiceFails()
         {
             // arrange
             var currentOpportunitiesSegmentModel = A.Fake<CurrentOpportunitiesSegmentModel>();
@@ -136,14 +136,14 @@ namespace DFC.App.JobProfile.CurrentOpportunities.SegmentService.UnitTests.Segme
             A.CallTo(() => FakeCourseCurrentOpportunitiesRefresh.RefreshCoursesAsync(currentOpportunitiesSegmentModel.DocumentId)).Returns(2);
 
             // act
-            var result = CurrentOpportunitiesSegmentService.UpsertAsync(currentOpportunitiesSegmentModel).Result;
+            var result = await CurrentOpportunitiesSegmentService.UpsertAsync(currentOpportunitiesSegmentModel).ConfigureAwait(false);
 
             // asserts
             A.CallTo(() => FakeJobProfileSegmentRefreshService.SendMessageAsync(A<RefreshJobProfileSegmentServiceBusModel>.Ignored)).MustHaveHappened();
         }
 
         [Fact]
-        public void RefreshJobProfileMessageNotSentWhenCourseAndAVServiceFails()
+        public async Task RefreshJobProfileMessageNotSentWhenCourseAndAVServiceFails()
         {
             // arrange
             var currentOpportunitiesSegmentModel = A.Fake<CurrentOpportunitiesSegmentModel>();
@@ -152,7 +152,7 @@ namespace DFC.App.JobProfile.CurrentOpportunities.SegmentService.UnitTests.Segme
             A.CallTo(() => FakeCourseCurrentOpportunitiesRefresh.RefreshCoursesAsync(currentOpportunitiesSegmentModel.DocumentId)).Throws(new HttpRequestException());
 
             // act
-            var result = CurrentOpportunitiesSegmentService.UpsertAsync(currentOpportunitiesSegmentModel).Result;
+            var result = await CurrentOpportunitiesSegmentService.UpsertAsync(currentOpportunitiesSegmentModel).ConfigureAwait(false);
 
             // asserts
             A.CallTo(() => FakeJobProfileSegmentRefreshService.SendMessageAsync(A<RefreshJobProfileSegmentServiceBusModel>.Ignored)).MustNotHaveHappened();

--- a/DFC.App.JobProfile.CurrentOpportunities.SegmentService.UnitTests/SegmentServiceTests/SegmentServiceUpsertTests.cs
+++ b/DFC.App.JobProfile.CurrentOpportunities.SegmentService.UnitTests/SegmentServiceTests/SegmentServiceUpsertTests.cs
@@ -157,7 +157,5 @@ namespace DFC.App.JobProfile.CurrentOpportunities.SegmentService.UnitTests.Segme
             // asserts
             A.CallTo(() => FakeJobProfileSegmentRefreshService.SendMessageAsync(A<RefreshJobProfileSegmentServiceBusModel>.Ignored)).MustNotHaveHappened();
         }
-
-
     }
 }

--- a/DFC.App.JobProfile.CurrentOpportunities/Controllers/SegmentController.cs
+++ b/DFC.App.JobProfile.CurrentOpportunities/Controllers/SegmentController.cs
@@ -174,6 +174,7 @@ namespace DFC.App.JobProfile.CurrentOpportunities.Controllers
 
             if (currentOpportunitiesSegmentModel.SequenceNumber <= existingDocument.SequenceNumber)
             {
+                logService.LogWarning($"{nameof(Post)} Sequence error {currentOpportunitiesSegmentModel.SequenceNumber} is not greate then the current document {existingDocument.SequenceNumber}");
                 return new StatusCodeResult((int)HttpStatusCode.AlreadyReported);
             }
 


### PR DESCRIPTION
Added handling and logging of exception around call to external services.
If one service fails we still do a refresh for the others.