### PR TITLE
NCSLT-409 implementing HTTP Client Factory changes in additional places

### DIFF
--- a/DFC.App.JobProfile.CurrentOpportunities.MFA.UnitTests/DFC.App.JobProfile.CurrentOpportunities.MFA.UnitTests.csproj
+++ b/DFC.App.JobProfile.CurrentOpportunities.MFA.UnitTests/DFC.App.JobProfile.CurrentOpportunities.MFA.UnitTests.csproj
@@ -20,6 +20,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.0" />
+    <PackageReference Include="Moq" Version="4.17.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/DFC.App.JobProfile.CurrentOpportunities.MFA.UnitTests/Services/HttpClientServiceDeleteTests.cs
+++ b/DFC.App.JobProfile.CurrentOpportunities.MFA.UnitTests/Services/HttpClientServiceDeleteTests.cs
@@ -3,6 +3,7 @@ using DFC.App.JobProfile.CurrentOpportunities.MessageFunctionApp.Services;
 using DFC.App.JobProfile.CurrentOpportunities.MFA.UnitTests.FakeHttpHandlers;
 using DFC.Logger.AppInsights.Contracts;
 using FakeItEasy;
+using Moq;
 using System;
 using System.Net;
 using System.Net.Http;
@@ -14,6 +15,7 @@ namespace DFC.App.JobProfile.CurrentOpportunities.MFA.UnitTests.Services
     [Trait("Messaging Function", "HttpClientService Delete Tests")]
     public class HttpClientServiceDeleteTests
     {
+        private Mock<IHttpClientFactory> mockFactory;
         private readonly ILogService logService;
         private readonly ICorrelationIdProvider correlationIdProvider;
         private readonly CoreClientOptions coreClientOptions;
@@ -28,6 +30,13 @@ namespace DFC.App.JobProfile.CurrentOpportunities.MFA.UnitTests.Services
             };
         }
 
+        public Mock<IHttpClientFactory> CreateClientFactory(HttpClient httpClient)
+        {
+            mockFactory = new Mock<IHttpClientFactory>();
+            mockFactory.Setup(_ => _.CreateClient(It.IsAny<string>())).Returns(httpClient);
+            return mockFactory;
+        }
+
         [Fact]
         public async Task DeleteAsyncReturnsOkStatusCodeForExistingId()
         {
@@ -37,7 +46,7 @@ namespace DFC.App.JobProfile.CurrentOpportunities.MFA.UnitTests.Services
             var fakeHttpRequestSender = A.Fake<IFakeHttpRequestSender>();
             var fakeHttpMessageHandler = new FakeHttpMessageHandler(fakeHttpRequestSender);
             var httpClient = new HttpClient(fakeHttpMessageHandler) { BaseAddress = coreClientOptions.BaseAddress };
-            var httpClientService = new HttpClientService(coreClientOptions, httpClient, logService, correlationIdProvider);
+            var httpClientService = new HttpClientService(coreClientOptions, CreateClientFactory(httpClient).Object, logService, correlationIdProvider);
 
             A.CallTo(() => fakeHttpRequestSender.Send(A<HttpRequestMessage>.Ignored)).Returns(httpResponse);
 
@@ -62,7 +71,7 @@ namespace DFC.App.JobProfile.CurrentOpportunities.MFA.UnitTests.Services
             var fakeHttpRequestSender = A.Fake<IFakeHttpRequestSender>();
             var fakeHttpMessageHandler = new FakeHttpMessageHandler(fakeHttpRequestSender);
             var httpClient = new HttpClient(fakeHttpMessageHandler) { BaseAddress = coreClientOptions.BaseAddress };
-            var httpClientService = new HttpClientService(coreClientOptions, httpClient, logService, correlationIdProvider);
+            var httpClientService = new HttpClientService(coreClientOptions, CreateClientFactory(httpClient).Object, logService, correlationIdProvider);
 
             A.CallTo(() => fakeHttpRequestSender.Send(A<HttpRequestMessage>.Ignored)).Returns(httpResponse);
 
@@ -87,7 +96,7 @@ namespace DFC.App.JobProfile.CurrentOpportunities.MFA.UnitTests.Services
             var fakeHttpRequestSender = A.Fake<IFakeHttpRequestSender>();
             var fakeHttpMessageHandler = new FakeHttpMessageHandler(fakeHttpRequestSender);
             var httpClient = new HttpClient(fakeHttpMessageHandler) { BaseAddress = coreClientOptions.BaseAddress };
-            var httpClientService = new HttpClientService(coreClientOptions, httpClient, logService, correlationIdProvider);
+            var httpClientService = new HttpClientService(coreClientOptions, CreateClientFactory(httpClient).Object, logService, correlationIdProvider);
 
             A.CallTo(() => fakeHttpRequestSender.Send(A<HttpRequestMessage>.Ignored)).Returns(httpResponse);
 

--- a/DFC.App.JobProfile.CurrentOpportunities.MFA.UnitTests/Services/HttpClientServicePatchTests.cs
+++ b/DFC.App.JobProfile.CurrentOpportunities.MFA.UnitTests/Services/HttpClientServicePatchTests.cs
@@ -4,6 +4,7 @@ using DFC.App.JobProfile.CurrentOpportunities.MessageFunctionApp.Services;
 using DFC.App.JobProfile.CurrentOpportunities.MFA.UnitTests.FakeHttpHandlers;
 using DFC.Logger.AppInsights.Contracts;
 using FakeItEasy;
+using Moq;
 using System;
 using System.Net;
 using System.Net.Http;
@@ -15,6 +16,7 @@ namespace DFC.App.JobProfile.CurrentOpportunities.MFA.UnitTests.Services
     [Trait("Messaging Function", "HttpClientService Patch Tests")]
     public class HttpClientServicePatchTests
     {
+        private Mock<IHttpClientFactory> mockFactory;
         private readonly ILogService logService;
         private readonly ICorrelationIdProvider correlationIdProvider;
         private readonly CoreClientOptions coreClientOptions;
@@ -29,6 +31,13 @@ namespace DFC.App.JobProfile.CurrentOpportunities.MFA.UnitTests.Services
             };
         }
 
+        public Mock<IHttpClientFactory> CreateClientFactory(HttpClient httpClient)
+        {
+            mockFactory = new Mock<IHttpClientFactory>();
+            mockFactory.Setup(_ => _.CreateClient(It.IsAny<string>())).Returns(httpClient);
+            return mockFactory;
+        }
+
         [Fact]
         public async Task PatchAsyncReturnsOkStatusCodeForExistingId()
         {
@@ -38,7 +47,7 @@ namespace DFC.App.JobProfile.CurrentOpportunities.MFA.UnitTests.Services
             var fakeHttpRequestSender = A.Fake<IFakeHttpRequestSender>();
             var fakeHttpMessageHandler = new FakeHttpMessageHandler(fakeHttpRequestSender);
             var httpClient = new HttpClient(fakeHttpMessageHandler) { BaseAddress = coreClientOptions.BaseAddress };
-            var httpClientService = new HttpClientService(coreClientOptions, httpClient, logService, correlationIdProvider);
+            var httpClientService = new HttpClientService(coreClientOptions, CreateClientFactory(httpClient).Object, logService, correlationIdProvider);
 
             A.CallTo(() => fakeHttpRequestSender.Send(A<HttpRequestMessage>.Ignored)).Returns(httpResponse);
 
@@ -63,7 +72,7 @@ namespace DFC.App.JobProfile.CurrentOpportunities.MFA.UnitTests.Services
             var fakeHttpRequestSender = A.Fake<IFakeHttpRequestSender>();
             var fakeHttpMessageHandler = new FakeHttpMessageHandler(fakeHttpRequestSender);
             var httpClient = new HttpClient(fakeHttpMessageHandler) { BaseAddress = coreClientOptions.BaseAddress };
-            var httpClientService = new HttpClientService(coreClientOptions, httpClient, logService, correlationIdProvider);
+            var httpClientService = new HttpClientService(coreClientOptions, CreateClientFactory(httpClient).Object, logService, correlationIdProvider);
 
             A.CallTo(() => fakeHttpRequestSender.Send(A<HttpRequestMessage>.Ignored)).Returns(httpResponse);
 
@@ -88,7 +97,7 @@ namespace DFC.App.JobProfile.CurrentOpportunities.MFA.UnitTests.Services
             var fakeHttpRequestSender = A.Fake<IFakeHttpRequestSender>();
             var fakeHttpMessageHandler = new FakeHttpMessageHandler(fakeHttpRequestSender);
             var httpClient = new HttpClient(fakeHttpMessageHandler) { BaseAddress = coreClientOptions.BaseAddress };
-            var httpClientService = new HttpClientService(coreClientOptions, httpClient, logService, correlationIdProvider);
+            var httpClientService = new HttpClientService(coreClientOptions, CreateClientFactory(httpClient).Object, logService, correlationIdProvider);
 
             A.CallTo(() => fakeHttpRequestSender.Send(A<HttpRequestMessage>.Ignored)).Returns(httpResponse);
 

--- a/DFC.App.JobProfile.CurrentOpportunities.MFA.UnitTests/Services/HttpClientServicePostTests.cs
+++ b/DFC.App.JobProfile.CurrentOpportunities.MFA.UnitTests/Services/HttpClientServicePostTests.cs
@@ -4,6 +4,7 @@ using DFC.App.JobProfile.CurrentOpportunities.MessageFunctionApp.Services;
 using DFC.App.JobProfile.CurrentOpportunities.MFA.UnitTests.FakeHttpHandlers;
 using DFC.Logger.AppInsights.Contracts;
 using FakeItEasy;
+using Moq;
 using System;
 using System.Net;
 using System.Net.Http;
@@ -15,6 +16,7 @@ namespace DFC.App.JobProfile.CurrentOpportunities.MFA.UnitTests.Services
     [Trait("Messaging Function", "HttpClientService Post Tests")]
     public class HttpClientServicePostTests
     {
+        private Mock<IHttpClientFactory> mockFactory;
         private readonly ILogService logService;
         private readonly ICorrelationIdProvider correlationIdProvider;
         private readonly CoreClientOptions coreClientOptions;
@@ -29,6 +31,13 @@ namespace DFC.App.JobProfile.CurrentOpportunities.MFA.UnitTests.Services
             };
         }
 
+        public Mock<IHttpClientFactory> CreateClientFactory(HttpClient httpClient)
+        {
+            mockFactory = new Mock<IHttpClientFactory>();
+            mockFactory.Setup(_ => _.CreateClient(It.IsAny<string>())).Returns(httpClient);
+            return mockFactory;
+        }
+
         [Fact]
         public async Task PostFullJobProfileAsyncReturnsOkStatusCodeForExistingId()
         {
@@ -38,7 +47,7 @@ namespace DFC.App.JobProfile.CurrentOpportunities.MFA.UnitTests.Services
             var fakeHttpRequestSender = A.Fake<IFakeHttpRequestSender>();
             var fakeHttpMessageHandler = new FakeHttpMessageHandler(fakeHttpRequestSender);
             var httpClient = new HttpClient(fakeHttpMessageHandler) { BaseAddress = coreClientOptions.BaseAddress };
-            var httpClientService = new HttpClientService(coreClientOptions, httpClient, logService, correlationIdProvider);
+            var httpClientService = new HttpClientService(coreClientOptions, CreateClientFactory(httpClient).Object, logService, correlationIdProvider);
 
             A.CallTo(() => fakeHttpRequestSender.Send(A<HttpRequestMessage>.Ignored)).Returns(httpResponse);
 
@@ -63,7 +72,7 @@ namespace DFC.App.JobProfile.CurrentOpportunities.MFA.UnitTests.Services
             var fakeHttpRequestSender = A.Fake<IFakeHttpRequestSender>();
             var fakeHttpMessageHandler = new FakeHttpMessageHandler(fakeHttpRequestSender);
             var httpClient = new HttpClient(fakeHttpMessageHandler) { BaseAddress = coreClientOptions.BaseAddress };
-            var httpClientService = new HttpClientService(coreClientOptions, httpClient, logService, correlationIdProvider);
+            var httpClientService = new HttpClientService(coreClientOptions, CreateClientFactory(httpClient).Object, logService, correlationIdProvider);
 
             A.CallTo(() => fakeHttpRequestSender.Send(A<HttpRequestMessage>.Ignored)).Returns(httpResponse);
 

--- a/DFC.App.JobProfile.CurrentOpportunities.MFA.UnitTests/Services/HttpClientServicePutTests.cs
+++ b/DFC.App.JobProfile.CurrentOpportunities.MFA.UnitTests/Services/HttpClientServicePutTests.cs
@@ -4,6 +4,7 @@ using DFC.App.JobProfile.CurrentOpportunities.MessageFunctionApp.Services;
 using DFC.App.JobProfile.CurrentOpportunities.MFA.UnitTests.FakeHttpHandlers;
 using DFC.Logger.AppInsights.Contracts;
 using FakeItEasy;
+using Moq;
 using System;
 using System.Net;
 using System.Net.Http;
@@ -15,6 +16,7 @@ namespace DFC.App.JobProfile.CurrentOpportunities.MFA.UnitTests.Services
     [Trait("Messaging Function", "HttpClientService Put Tests")]
     public class HttpClientServicePutTests
     {
+        private Mock<IHttpClientFactory> mockFactory;
         private readonly ILogService logService;
         private readonly ICorrelationIdProvider correlationIdProvider;
         private readonly CoreClientOptions coreClientOptions;
@@ -29,6 +31,13 @@ namespace DFC.App.JobProfile.CurrentOpportunities.MFA.UnitTests.Services
             };
         }
 
+        public Mock<IHttpClientFactory> CreateClientFactory(HttpClient httpClient)
+        {
+            mockFactory = new Mock<IHttpClientFactory>();
+            mockFactory.Setup(_ => _.CreateClient(It.IsAny<string>())).Returns(httpClient);
+            return mockFactory;
+        }
+
         [Fact]
         public async Task PutFullJobProfileAsyncReturnsOkStatusCodeForExistingId()
         {
@@ -38,7 +47,7 @@ namespace DFC.App.JobProfile.CurrentOpportunities.MFA.UnitTests.Services
             var fakeHttpRequestSender = A.Fake<IFakeHttpRequestSender>();
             var fakeHttpMessageHandler = new FakeHttpMessageHandler(fakeHttpRequestSender);
             var httpClient = new HttpClient(fakeHttpMessageHandler) { BaseAddress = coreClientOptions.BaseAddress };
-            var httpClientService = new HttpClientService(coreClientOptions, httpClient, logService, correlationIdProvider);
+            var httpClientService = new HttpClientService(coreClientOptions, CreateClientFactory(httpClient).Object, logService, correlationIdProvider);
 
             A.CallTo(() => fakeHttpRequestSender.Send(A<HttpRequestMessage>.Ignored)).Returns(httpResponse);
 
@@ -63,7 +72,7 @@ namespace DFC.App.JobProfile.CurrentOpportunities.MFA.UnitTests.Services
             var fakeHttpRequestSender = A.Fake<IFakeHttpRequestSender>();
             var fakeHttpMessageHandler = new FakeHttpMessageHandler(fakeHttpRequestSender);
             var httpClient = new HttpClient(fakeHttpMessageHandler) { BaseAddress = coreClientOptions.BaseAddress };
-            var httpClientService = new HttpClientService(coreClientOptions, httpClient, logService, correlationIdProvider);
+            var httpClientService = new HttpClientService(coreClientOptions, CreateClientFactory(httpClient).Object, logService, correlationIdProvider);
 
             A.CallTo(() => fakeHttpRequestSender.Send(A<HttpRequestMessage>.Ignored)).Returns(httpResponse);
 
@@ -88,7 +97,7 @@ namespace DFC.App.JobProfile.CurrentOpportunities.MFA.UnitTests.Services
             var fakeHttpRequestSender = A.Fake<IFakeHttpRequestSender>();
             var fakeHttpMessageHandler = new FakeHttpMessageHandler(fakeHttpRequestSender);
             var httpClient = new HttpClient(fakeHttpMessageHandler) { BaseAddress = coreClientOptions.BaseAddress };
-            var httpClientService = new HttpClientService(coreClientOptions, httpClient, logService, correlationIdProvider);
+            var httpClientService = new HttpClientService(coreClientOptions, CreateClientFactory(httpClient).Object, logService, correlationIdProvider);
 
             A.CallTo(() => fakeHttpRequestSender.Send(A<HttpRequestMessage>.Ignored)).Returns(httpResponse);
 

--- a/DFC.App.JobProfile.CurrentOpportunities.MessageFunctionApp/Services/HttpClientService.cs
+++ b/DFC.App.JobProfile.CurrentOpportunities.MessageFunctionApp/Services/HttpClientService.cs
@@ -20,10 +20,10 @@ namespace DFC.App.JobProfile.CurrentOpportunities.MessageFunctionApp.Services
         private readonly ILogService logService;
         private readonly ICorrelationIdProvider correlationIdProvider;
 
-        public HttpClientService(CoreClientOptions segmentClientOptions, HttpClient httpClient, ILogService logService, ICorrelationIdProvider correlationIdProvider)
+        public HttpClientService(CoreClientOptions segmentClientOptions, IHttpClientFactory httpClientFactory, ILogService logService, ICorrelationIdProvider correlationIdProvider)
         {
             this.coreClientOptions = segmentClientOptions;
-            this.httpClient = httpClient;
+            this.httpClient = httpClientFactory.CreateClient();
             this.logService = logService;
             this.correlationIdProvider = correlationIdProvider;
         }

--- a/DFC.App.JobProfile.CurrentOpportunities.MessageFunctionApp/Startup/WebJobsExtensionStartup.cs
+++ b/DFC.App.JobProfile.CurrentOpportunities.MessageFunctionApp/Startup/WebJobsExtensionStartup.cs
@@ -57,7 +57,7 @@ namespace DFC.App.JobProfile.CurrentOpportunities.MessageFunctionApp.Startup
                 .AddScoped<IMessagePropertiesService, MessagePropertiesService>()
                 .AddDFCLogging(configuration["APPINSIGHTS_INSTRUMENTATIONKEY"])
                 .AddScoped<ICorrelationIdProvider, InMemoryCorrelationIdProvider>()
-                .AddSingleton(new HttpClient());
+                .AddHttpClient();
 
             var sp = builder.Services.BuildServiceProvider();
             var mapper = sp.GetService<IMapper>();


### PR DESCRIPTION
Use IHttpClientFactory instead of instantiating HttpClient class.